### PR TITLE
Correcting there unwrapping algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-VERSION=1.4
+VERSION=1.5
 TCLINC=-I/usr/include/tcl8.6
 TCLLIB=-I/usr/lib64
 PLUGINDIR=${HOME}/lib/vmd/plugins/LINUXAMD64/tcl

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## Development news
 As of version 1.4, unwrapping is done according to the algorithm of von Bülow, Bullerjahn and Hummer (https://arxiv.org/pdf/2003.09205.pdf) to obtain correct diffusion coefficient at long times.
+Additionally, a correction term is applied to consider that the barostat scales coordinates.
 Note that the algorithm used up to version 1.3 was already similar to this one, and gave only small, bounded deviations from the true long-time diffusion.
 
 ## Using without installing

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 [![DOI](https://zenodo.org/badge/31314121.svg)](https://zenodo.org/badge/latestdoi/31314121)
 
 ## Development news
+In version 1.5, an additional correction term is applied to consider that the barostat scales coordinates.
+
 As of version 1.4, unwrapping is done according to the algorithm of von Bülow, Bullerjahn and Hummer (https://arxiv.org/pdf/2003.09205.pdf) to obtain correct diffusion coefficient at long times.
-Additionally, a correction term is applied to consider that the barostat scales coordinates.
 Note that the algorithm used up to version 1.3 was already similar to this one, and gave only small, bounded deviations from the true long-time diffusion.
 
 ## Using without installing


### PR DESCRIPTION
The heuristic unwrapping method leads to unwrapping errors in long NPT trajectories, where atoms traversed multiple periodic boxes. We developed and implemented a new unwrapping algorithm based on the displacement method "https://doi.org/10.48550/arXiv.2111.12052" that corrects this. The current implementation only works for orthorhombic boxes.